### PR TITLE
Add a new function to update all transfer restrictions at once

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,54 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Tests
+
+on:
+  push:
+    
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:      
+    - uses: actions/checkout@v2
+      
+    - name: Set up Algorand Node
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y gnupg2 curl software-properties-common
+        curl -O https://releases.algorand.com/key.pub
+        sudo apt-key add key.pub
+        sudo add-apt-repository "deb https://releases.algorand.com/deb/ stable main"
+        sudo apt-get update
+        sudo apt-get install -y algorand-devtools
+        
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 pytest pyteal
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+    - name: Compile TEAL
+      run: |
+        python security_token.py
+      
+    - name: Setup Node.js environment
+      uses: actions/setup-node@v2.1.4
+    
+    - name: Install Node dependencies
+      run: yarn install
+      
+    - name: Run Tests
+      run: yarn test
+

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,3 @@
-# This workflow will install Python dependencies, run tests and lint with a single version of Python
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
-
 name: Tests
 
 on:
@@ -22,22 +19,17 @@ jobs:
         sudo add-apt-repository "deb https://releases.algorand.com/deb/ stable main"
         sudo apt-get update
         sudo apt-get install -y algorand-devtools
-        
+        mkdir devnet
+      
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
         python-version: 3.9
-    - name: Install dependencies
+    - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest pyteal
+        pip install pytest pyteal
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
     - name: Compile TEAL
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,7 @@ name: Tests
 
 on:
   push:
+  pull_request:
     
 jobs:
   test:
@@ -19,7 +20,6 @@ jobs:
         sudo add-apt-repository "deb https://releases.algorand.com/deb/ stable main"
         sudo apt-get update
         sudo apt-get install -y algorand-devtools
-        mkdir devnet
       
     - name: Set up Python
       uses: actions/setup-python@v2

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ The TEAL assembly smart contract language uses program branches with no loops (i
 | ["max balance"](bin/max-balance.sh) | Sets the max number of tokens an account can hold | transfer admin |
 | ["lock until"](bin/lock-until.sh) | Stop transfers from the address until the specified date. A locked address can still receive tokens but it cannot send them until the lockup time. | transfer admin |
 | ["transfer group" "set"](bin/transfer-group-set.sh) | Sets the category of an address for use in transfer group rules. The default category is 1. | transfer admin |
+| ["transfer restrictions"](tests/set_transfer_restrictions.test.js) | Sets all account transfer restrictions (`freeze`, `max balance`, `lock until`, `transfer group`) in one call. | transfer admin |
 | ["transfer group" "lock"](bin/transfer-group-lock.sh) | Specifies a lock until time for transfers between a transfer from-group and a to-group. Transfers can between groups can only occur after the lock until time. The lock until time is specified as a Unix timestamp integer in seconds since the Unix Epoch. By default transfers beetween groups are not allowed. To allow a transfer set a timestamp in the past such as "1" - for the from and to group pair . The special transfer group default number "0" means the transfer is blocked.  | transfer admin |
 | ["mint"](bin/mint.sh) | Create new tokens from the reserve | contract admin |
 | ["burn"](tests/burn.test.js) | Destroy tokens from a specified address | contract admin |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ __Although we hope this code is useful to you, it comes with no warranty of any 
 * `git clone` this Algorand Security Token repository
 * Install node.js from [Nodejs.org](https://nodejs.org)
 * Follow the Algorand blockchain node [setup instructions](https://developer.algorand.org/docs/run-a-node/setup/install/). You will need this to run tests and scripts. You will know it's installed if you get the help info when you run `goal -h` from the command line.
-* Install Python
+* Install Python 3 and [pyteal](https://developer.algorand.org/docs/features/asc1/teal/pyteal/)
 * Get a purestake.com API key to deploy to testnet / mainnet using hosted nodes
 * `cp .env.example .env` and enter your environment variables
 * If you want to run a local node that syncs with testnet try https://github.com/algorand/sandbox - it will sync to testnet in minutes instead of days.

--- a/bin/start-devnet.sh
+++ b/bin/start-devnet.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 export ALGOSMALLLAMBDAMSEC=200 # confirm private blockchain blocks fast
-NETWORK_DIR=${1:-"$(PWD)/devnet"}
+NETWORK_DIR=${1:-"$(pwd)/devnet"}
 NETWORK_PRIMARY_KEY="${NETWORK_DIR}/Primary"
 DEVNET_KMD="${NETWORK_PRIMARY_KEY}/kmd-v0.5"
 CONFIG_DIR=./config/genesis.devnet.json

--- a/bin/stop-devnet.sh
+++ b/bin/stop-devnet.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-NETWORK_DIR=${1:-"$(PWD)/devnet"}
+NETWORK_DIR=${1:-"$(pwd)/devnet"}
 NETWORK_PRIMARY_KEY="${NETWORK_DIR}/Primary"
 # NETWORK_PORT=${2:-8080}
 CONFIG_DIR=./config/genesis.devnet.json

--- a/security_token.py
+++ b/security_token.py
@@ -135,7 +135,7 @@ def approval_program():
             App.localDel(Int(1), Bytes("lock until")),
             App.localPut(Int(1), Bytes("lock until"), lock_until_value)
         ),
-        App.localPut(Int(1), Bytes("transfer group"), transfer_group_value)
+        App.localPut(Int(1), Bytes("transfer group"), transfer_group_value),
         Return(is_transfer_admin)
     ])
 

--- a/security_token.py
+++ b/security_token.py
@@ -115,6 +115,30 @@ def approval_program():
         App.localPut(Int(1), Bytes("transfer group"), Btoi(Txn.application_args[2]))
     ])
 
+    # sets all transfer restrictions for Txn.accounts[0]
+    # sender must be transfer admin
+    freeze_value = Btoi(Txn.application_args[1])
+    max_balance_value = Btoi(Txn.application_args[2])
+    lock_until_value = Btoi(Txn.application_args[3])
+    transfer_group_value = Btoi(Txn.application_args[4])
+    transfer_restrictions = Seq([
+        Assert(And(
+            Txn.application_args.length() == Int(5),
+            Txn.accounts.length() == Int(1)
+        )),
+        App.localPut(Int(1), Bytes("frozen"), freeze_value),
+        If(max_balance_value == Int(0),
+            App.localDel(Int(1), Bytes("max balance")),
+            App.localPut(Int(1), Bytes("max balance"), max_balance_value)
+        ),
+        If(lock_until_value == Int(0),
+            App.localDel(Int(1), Bytes("lock until")),
+            App.localPut(Int(1), Bytes("lock until"), lock_until_value)
+        ),
+        App.localPut(Int(1), Bytes("transfer group"), transfer_group_value)
+        Return(is_transfer_admin)
+    ])
+
     def getRuleKey(sendGroup, receiveGroup):
         return Concat(Bytes("rule"), Itob(sendGroup), Itob(receiveGroup))
 
@@ -207,6 +231,7 @@ def approval_program():
         [Txn.application_args[0] == Bytes("max balance"), max_balance],
         [Txn.application_args[0] == Bytes("lock until"), lock_until],
         [Txn.application_args[0] == Bytes("transfer group"), transfer_group],
+        [Txn.application_args[0] == Bytes("transfer restrictions"), transfer_restrictions],
         [Txn.application_args[0] == Bytes("mint"), mint],
         [Txn.application_args[0] == Bytes("burn"), burn],
         [Txn.application_args[0] == Bytes("transfer"), transfer],

--- a/security_token_approval.teal
+++ b/security_token_approval.teal
@@ -44,25 +44,29 @@ byte "transfer group"
 ==
 bnz l10
 txna ApplicationArgs 0
-byte "mint"
+byte "transfer restrictions"
 ==
 bnz l11
 txna ApplicationArgs 0
-byte "burn"
+byte "mint"
 ==
 bnz l12
 txna ApplicationArgs 0
-byte "transfer"
+byte "burn"
 ==
 bnz l13
+txna ApplicationArgs 0
+byte "transfer"
+==
+bnz l14
 err
 l0:
 txn NumAppArgs
 int 3
 ==
-bnz l15
+bnz l16
 err
-l15:
+l16:
 byte "total supply"
 txna ApplicationArgs 0
 btoi
@@ -99,7 +103,7 @@ int 0
 app_local_put
 int 1
 return
-b l14
+b l15
 l1:
 int 0
 byte "contract admin"
@@ -111,13 +115,13 @@ app_global_get
 ==
 &&
 return
-b l14
+b l15
 l2:
 int 0
 byte "contract admin"
 app_local_get
 return
-b l14
+b l15
 l3:
 byte "reserve"
 byte "reserve"
@@ -129,7 +133,7 @@ app_local_get
 app_global_put
 int 1
 return
-b l14
+b l15
 l4:
 int 0
 byte "balance"
@@ -141,14 +145,14 @@ int 1
 app_local_put
 int 1
 return
-b l14
+b l15
 l5:
 txn NumAppArgs
 int 2
 ==
-bnz l16
+bnz l17
 err
-l16:
+l17:
 byte "paused"
 txna ApplicationArgs 1
 btoi
@@ -157,7 +161,7 @@ int 0
 byte "contract admin"
 app_local_get
 return
-b l14
+b l15
 l6:
 int 0
 byte "contract admin"
@@ -178,9 +182,9 @@ txn NumAccounts
 int 1
 ==
 &&
-bnz l17
+bnz l18
 err
-l17:
+l18:
 int 1
 txna ApplicationArgs 1
 txna ApplicationArgs 2
@@ -188,29 +192,8 @@ btoi
 app_local_put
 int 1
 return
-b l14
+b l15
 l7:
-txn NumAppArgs
-int 2
-==
-txn NumAccounts
-int 1
-==
-&&
-bnz l18
-err
-l18:
-int 1
-byte "frozen"
-txna ApplicationArgs 1
-btoi
-app_local_put
-int 0
-byte "transfer admin"
-app_local_get
-return
-b l14
-l8:
 txn NumAppArgs
 int 2
 ==
@@ -221,27 +204,48 @@ int 1
 bnz l19
 err
 l19:
+int 1
+byte "frozen"
+txna ApplicationArgs 1
+btoi
+app_local_put
+int 0
+byte "transfer admin"
+app_local_get
+return
+b l15
+l8:
+txn NumAppArgs
+int 2
+==
+txn NumAccounts
+int 1
+==
+&&
+bnz l20
+err
+l20:
 txna ApplicationArgs 1
 btoi
 int 0
 ==
-bnz l20
+bnz l21
 int 1
 byte "max balance"
 txna ApplicationArgs 1
 btoi
 app_local_put
-b l21
-l20:
+b l22
+l21:
 int 1
 byte "max balance"
 app_local_del
-l21:
+l22:
 int 0
 byte "transfer admin"
 app_local_get
 return
-b l14
+b l15
 l9:
 txn NumAppArgs
 int 2
@@ -250,47 +254,47 @@ txn NumAccounts
 int 1
 ==
 &&
-bnz l22
+bnz l23
 err
-l22:
+l23:
 txna ApplicationArgs 1
 btoi
 int 0
 ==
-bnz l23
+bnz l24
 int 1
 byte "lock until"
 txna ApplicationArgs 1
 btoi
 app_local_put
-b l24
-l23:
+b l25
+l24:
 int 1
 byte "lock until"
 app_local_del
-l24:
+l25:
 int 0
 byte "transfer admin"
 app_local_get
 return
-b l14
+b l15
 l10:
 txn NumAppArgs
 int 2
 >
-bnz l25
+bnz l26
 err
-l25:
+l26:
 txna ApplicationArgs 1
 byte "set"
 ==
-bnz l26
+bnz l27
 txna ApplicationArgs 1
 byte "lock"
 ==
-bnz l27
+bnz l28
 err
-l26:
+l27:
 txn NumAppArgs
 int 3
 ==
@@ -298,27 +302,27 @@ txn NumAccounts
 int 1
 ==
 &&
-bnz l29
+bnz l30
 err
-l29:
+l30:
 int 1
 byte "transfer group"
 txna ApplicationArgs 2
 btoi
 app_local_put
-b l28
-l27:
+b l29
+l28:
 txn NumAppArgs
 int 5
 ==
-bnz l30
+bnz l31
 err
-l30:
+l31:
 txna ApplicationArgs 4
 btoi
 int 0
 ==
-bnz l31
+bnz l32
 byte "rule"
 txna ApplicationArgs 2
 btoi
@@ -331,8 +335,8 @@ concat
 txna ApplicationArgs 4
 btoi
 app_global_put
-b l32
-l31:
+b l33
+l32:
 byte "rule"
 txna ApplicationArgs 2
 btoi
@@ -343,51 +347,71 @@ btoi
 itob
 concat
 app_global_del
-l32:
-l28:
+l33:
+l29:
 int 0
 byte "transfer admin"
 app_local_get
 return
-b l14
+b l15
 l11:
 txn NumAppArgs
-int 2
+int 5
 ==
 txn NumAccounts
 int 1
 ==
 &&
-txna ApplicationArgs 1
-btoi
-byte "reserve"
-app_global_get
-<=
-&&
-bnz l33
+bnz l34
 err
-l33:
-byte "reserve"
-byte "reserve"
-app_global_get
+l34:
+int 1
+byte "frozen"
 txna ApplicationArgs 1
 btoi
--
-app_global_put
-int 1
-byte "balance"
-int 1
-byte "balance"
-app_local_get
-txna ApplicationArgs 1
+app_local_put
+txna ApplicationArgs 2
 btoi
-+
+int 0
+==
+bnz l35
+int 1
+byte "max balance"
+txna ApplicationArgs 2
+btoi
+app_local_put
+b l36
+l35:
+int 1
+byte "max balance"
+app_local_del
+l36:
+txna ApplicationArgs 3
+btoi
+int 0
+==
+bnz l37
+int 1
+byte "lock until"
+txna ApplicationArgs 3
+btoi
+app_local_put
+b l38
+l37:
+int 1
+byte "lock until"
+app_local_del
+l38:
+int 1
+byte "transfer group"
+txna ApplicationArgs 4
+btoi
 app_local_put
 int 0
-byte "contract admin"
+byte "transfer admin"
 app_local_get
 return
-b l14
+b l15
 l12:
 txn NumAppArgs
 int 2
@@ -398,14 +422,52 @@ int 1
 &&
 txna ApplicationArgs 1
 btoi
+byte "reserve"
+app_global_get
+<=
+&&
+bnz l39
+err
+l39:
+byte "reserve"
+byte "reserve"
+app_global_get
+txna ApplicationArgs 1
+btoi
+-
+app_global_put
+int 1
+byte "balance"
+int 1
+byte "balance"
+app_local_get
+txna ApplicationArgs 1
+btoi
++
+app_local_put
+int 0
+byte "contract admin"
+app_local_get
+return
+b l15
+l13:
+txn NumAppArgs
+int 2
+==
+txn NumAccounts
+int 1
+==
+&&
+txna ApplicationArgs 1
+btoi
 int 1
 byte "balance"
 app_local_get
 <=
 &&
-bnz l34
+bnz l40
 err
-l34:
+l40:
 byte "reserve"
 byte "reserve"
 app_global_get
@@ -426,8 +488,8 @@ int 0
 byte "contract admin"
 app_local_get
 return
-b l14
-l13:
+b l15
+l14:
 txn NumAppArgs
 int 2
 ==
@@ -442,9 +504,9 @@ byte "balance"
 app_local_get
 <=
 &&
-bnz l35
+bnz l41
 err
-l35:
+l41:
 int 1
 global CurrentApplicationID
 byte "max balance"
@@ -504,10 +566,10 @@ btoi
 <
 &&
 ||
-bz l36
+bz l42
 int 0
 return
-l36:
+l42:
 int 0
 byte "balance"
 int 0
@@ -528,4 +590,4 @@ btoi
 app_local_put
 int 1
 return
-l14:
+l15:

--- a/tests/set_transfer_restrictions.test.js
+++ b/tests/set_transfer_restrictions.test.js
@@ -1,0 +1,37 @@
+require('dotenv').config()
+const shell = require('shelljs')
+const util = require('../lib/algoUtil')
+const {EncodeUint, EncodeBytes} = util
+const algosdk = require('algosdk')
+
+const server = "http://127.0.0.1"
+const port = 8080
+
+var adminAccount, receiverAccount, token, clientV2, appId
+
+beforeEach(async () => {
+    await privateTestNetSetup(appId)
+    adminAccount = accounts[0]
+    receiverAccount = accounts[1]
+
+    token = await shell.cat(`devnet/Primary/algod.token`).stdout
+    clientV2 = new algosdk.Algodv2(token, server, port)
+    let info = await util.deploySecurityToken(clientV2, adminAccount)
+    appId = info.appId
+
+    //opt in
+    await util.optInApp(clientV2, receiverAccount, appId)
+})
+
+test('admin can set transfer restrictions', async () => {
+    // call
+    appArgs = [EncodeBytes("transfer restrictions"), EncodeUint('1'), EncodeUint('199'), EncodeUint('1610126036'), EncodeUint('7')]
+    await util.appCall(clientV2, adminAccount, appId, appArgs, [receiverAccount.addr])
+
+    // account transfer restrictions has been updated
+    localState = await util.readLocalState(clientV2, receiverAccount, appId)
+    expect(localState["frozen"]["ui"]).toEqual(1)
+    expect(localState["max balance"]["ui"]).toEqual(199)
+    expect(localState["lock until"]["ui"]).toEqual(1610126036)
+    expect(localState["transfer group"]["ui"]).toEqual(7)
+})


### PR DESCRIPTION
The PR adds a function to set all account transfer restriction in one call.

### Arguments must be provided in the following order

```bash
--app-arg 'str:transfer restrictions' --app-arg int:freeze --app-arg int:maxBalance --app-arg int:lockUntil --app-arg int:transferGroup
```

### Example usage

```js
appArgs = [EncodeBytes("transfer restrictions"), EncodeUint('1'), EncodeUint('199'), EncodeUint('1610126036'), EncodeUint('7')]
await util.appCall(clientV2, adminAccount, appId, appArgs, [receiverAccount.addr])
```