### PR TITLE
Increase local state integer limit to 7

### DIFF
--- a/lib/algoUtil.js
+++ b/lib/algoUtil.js
@@ -121,7 +121,7 @@ exports.deploySecurityToken = async (algodClient,
     console.log(approvalTeal)
     let approvalProgram = await exports.compileProgram(algodClient, approvalTeal)
     let clearProgram = await exports.compileProgram(algodClient, clearTeal)
-    let localInts = 4
+    let localInts = 7
     let localBytes = 0
     let globalInts = 60
     let globalBytes = 1

--- a/tests/set_transfer_restrictions.test.js
+++ b/tests/set_transfer_restrictions.test.js
@@ -1,0 +1,50 @@
+require('dotenv').config()
+const shell = require('shelljs')
+const util = require('../lib/algoUtil')
+const {EncodeUint, EncodeBytes} = util
+const algosdk = require('algosdk')
+
+const server = "http://127.0.0.1"
+const port = 8080
+
+var adminAccount, receiverAccount, token, clientV2, appId
+
+beforeEach(async () => {
+    await privateTestNetSetup(appId)
+    adminAccount = accounts[0]
+    receiverAccount = accounts[1]
+
+    token = await shell.cat(`devnet/Primary/algod.token`).stdout
+    clientV2 = new algosdk.Algodv2(token, server, port)
+    let info = await util.deploySecurityToken(clientV2, adminAccount)
+    appId = info.appId
+
+    //opt in
+    await util.optInApp(clientV2, receiverAccount, appId)
+})
+
+test('admin can set transfer restrictions', async () => {
+    // call
+    appArgs = [EncodeBytes("transfer restrictions"), EncodeUint('1'), EncodeUint('199'), EncodeUint('1610126036'), EncodeUint('7')]
+    await util.appCall(clientV2, adminAccount, appId, appArgs, [receiverAccount.addr])
+
+    // account transfer restrictions has been updated
+    localState = await util.readLocalState(clientV2, receiverAccount, appId)
+    expect(localState["frozen"]["ui"]).toEqual(1)
+    expect(localState["max balance"]["ui"]).toEqual(199)
+    expect(localState["lock until"]["ui"]).toEqual(1610126036)
+    expect(localState["transfer group"]["ui"]).toEqual(7)
+})
+
+test('admin transfer restrictions can be set', async () => {
+  // call
+  appArgs = [EncodeBytes("transfer restrictions"), EncodeUint('1'), EncodeUint('199'), EncodeUint('1610126036'), EncodeUint('7')]
+  await util.appCall(clientV2, adminAccount, appId, appArgs, [adminAccount.addr])
+
+  // account transfer restrictions has been updated
+  localState = await util.readLocalState(clientV2, adminAccount, appId)
+  expect(localState["frozen"]["ui"]).toEqual(1)
+  expect(localState["max balance"]["ui"]).toEqual(199)
+  expect(localState["lock until"]["ui"]).toEqual(1610126036)
+  expect(localState["transfer group"]["ui"]).toEqual(7)
+})


### PR DESCRIPTION
Current local schema limited with 4 integers is unable to accommodate all possible values:

1. balance
2. transfer group
3. contract admin
4. transfer admin
5. frozen
6. max balance
7. lock until

The updated version is deployed to testnet with app id `13672272`