### PR TITLE
Do not allow app delete

### DIFF
--- a/security_token.py
+++ b/security_token.py
@@ -26,12 +26,11 @@ def approval_program():
         App.globalGet(Bytes("total supply")) == App.globalGet(Bytes("reserve"))
     )
 
+    # goal app closeout --app-id uint --from address
+    # to keep from deleting critical token balances do not allow the app to be closed out
+    # calling this will fail with "transaction rejected by ApprovalProgram"
     on_closeout = Seq([
-        App.globalPut(
-            Bytes("reserve"),
-            App.globalGet(Bytes("reserve")) + App.localGet(Int(0), Bytes("balance"))
-        ),
-        Return(Int(1))
+        Return(Int(0))
     ])
 
     # when an account opts-in set the accounts local variables

--- a/security_token_approval.teal
+++ b/security_token_approval.teal
@@ -111,15 +111,7 @@ app_local_get
 return
 b l12
 l3:
-byte "reserve"
-byte "reserve"
-app_global_get
 int 0
-byte "balance"
-app_local_get
-+
-app_global_put
-int 1
 return
 b l12
 l4:

--- a/tests/optin_and_out_of_app.test.js
+++ b/tests/optin_and_out_of_app.test.js
@@ -30,6 +30,22 @@ test("can opt in and when I opt out my balance is returned to the reserve", asyn
     let localState = await util.readLocalState(clientV2, newAccount, info.appId)
     expect(localState["balance"]["ui"]).toEqual(undefined)
     expect(localState["transfer group"]["ui"]).toEqual(1)
+})
 
-    //TODO: test opt out returns tokens to the reserve
+test("do not allow an account that has opted in to opt out / delete app", async () => {
+    let info = await util.deploySecurityToken(clientV2, adminAccount)
+    appId = info.appId
+    console.log(appId, adminAccount.addr)
+
+    await util.optInApp(clientV2, newAccount, appId)
+
+    let attemptOptOut = `goal app closeout --app-id ${appId} --from ${adminAccount.addr} -d devnet/Primary`
+
+    let response = await shell.exec(attemptOptOut, {async: false, silent: false})
+    expect(response.stderr).toMatch(/transaction rejected by ApprovalProgram/)
+    //check state has not been altered
+    let localState = await util.readLocalState(clientV2, newAccount, info.appId)
+    expect(localState["balance"]["ui"]).toEqual(undefined)
+    expect(localState["transfer group"]["ui"]).toEqual(1)
+
 })


### PR DESCRIPTION
Because it would destroy token balances and global state. This is too high risk and there seems to be very little benefit of allowing app delete or clearing for this app.