### PR TITLE
Draft detectTransferRestriction function

### DIFF
--- a/security_token.py
+++ b/security_token.py
@@ -277,6 +277,7 @@ def approval_program():
         [Txn.application_args[0] == Bytes("mint"), mint],
         [Txn.application_args[0] == Bytes("burn"), burn],
         [Txn.application_args[0] == Bytes("transfer"), transfer],
+        [Txn.application_args[0] == Bytes("detectTransferRestriction"), detectTransferRestriction],
     )
 
     return program

--- a/security_token.py
+++ b/security_token.py
@@ -201,7 +201,7 @@ def approval_program():
         Return(Int(1))
     ])
 
-    # accepts sender and receiver indexes in current Txn.accounts[]
+    # accepts sender and receiver indices in current Txn.accounts[]
     # returns true if all checks are succesfull and transfer is allowed
     def isTransferAllowed(sender_idx, receiver_idx, amount):
         return Not(Or(

--- a/security_token.py
+++ b/security_token.py
@@ -201,6 +201,42 @@ def approval_program():
         Return(Int(1))
     ])
 
+    # accepts sender and receiver indexes in current Txn.accounts[]
+    # returns true if all checks are succesfull and transfer is allowed
+    def isTransferAllowed(sender_idx, receiver_idx, amount):
+        return Not(Or(
+            Lt(App.localGet(sender_idx, Bytes("balance")), amount), # check sender balance
+            App.globalGet(Bytes("paused")), # can't transfer when the contract is paused
+            App.localGet(sender_idx, Bytes("frozen")), # sender account can't be frozen
+            App.localGet(sender_idx, Bytes("lockUntil")) >= Global.latest_timestamp(), # sender account can't be locked
+
+            # check that a transfer rule exists and allows the transfer from the sender to the receiver at the current time
+            App.globalGet(getRuleKey(App.localGet(sender_idx, Bytes("transferGroup")), App.localGet(receiver_idx, Bytes("transferGroup")))) < Int(1),
+            App.globalGet(getRuleKey(App.localGet(sender_idx, Bytes("transferGroup")), App.localGet(receiver_idx, Bytes("transferGroup")))) >= Global.latest_timestamp(),
+
+            # check that max balance is not exceeded
+            And(
+                App.localGet(receiver_idx, Bytes("maxBalance")),
+                App.localGet(receiver_idx, Bytes("maxBalance")) < App.localGet(receiver_idx, Bytes("balance")) + amount
+            )
+        ))
+
+    # detectTransferRestriction
+    # transaction succeeds if transfer is possible from the sender Txn.accounts[1] to the receiver Txn.accounts[2]
+    # goal app call --app-id uint --from address --app-account senderAddr --app-account receiverAddr --app-arg 'str:detectTransferRestriction' --app-arg "int:amount"
+    # checks are made to see if the sender account is frozen or locked
+    # checks are made to see if there is a transfer rule allowing transfer between sender and receiver transfer groups
+    # the transfer must occur after the transfer group lockUntil date
+    transfer_amount = Btoi(Txn.application_args[1])
+    detectTransferRestriction = Seq([
+        Assert(And(
+            Txn.application_args.length() == Int(2),
+            Txn.accounts.length() == Int(2),
+            isTransferAllowed(Int(1), Int(2), transfer_amount)
+        )),
+        Return(Int(1))
+    ])
+
     # transfer
     # transfers assets from the sender to the receiver Txn.accounts[1]
     # goal app call --app-id uint --from address --app-account receiverAddr --app-arg 'str:transfer' --app-arg "int:amount"
@@ -208,33 +244,12 @@ def approval_program():
     # checks are made to see if there is a transfer rule allowing transfer between sender and receiver transfer groups
     # the transfer must occur after the transfer group lockUntil date
     transfer_amount = Btoi(Txn.application_args[1])
-    receiver_max_balance = App.localGetEx(Int(1), App.id(), Bytes("maxBalance"))
     transfer = Seq([
         Assert(And(
             Txn.application_args.length() == Int(2),
             Txn.accounts.length() == Int(1),
-            transfer_amount <= App.localGet(Int(0), Bytes("balance"))
+            isTransferAllowed(Int(0), Int(1), transfer_amount)
         )),
-
-        # transfer amount should not exceed the receiver maxBalance
-        # this can be used to enforce un-accredited investor maxBalances
-        receiver_max_balance,
-        If(
-            Or(
-                App.globalGet(Bytes("paused")), # can't transfer when the contract is paused
-                App.localGet(Int(0), Bytes("frozen")), # sender account can't be frozen
-                App.localGet(Int(0), Bytes("lockUntil")) >= Global.latest_timestamp(), # sender account can't be locked
-                App.globalGet(getRuleKey(App.localGet(Int(0), Bytes("transferGroup")), App.localGet(Int(1), Bytes("transferGroup")))) < Int(1),
-
-                # check that a transfer rule allows the transfer from the sender to the receiver at the current time
-                App.globalGet(getRuleKey(App.localGet(Int(0), Bytes("transferGroup")), App.localGet(Int(1), Bytes("transferGroup")))) >= Global.latest_timestamp(),
-                And(
-                    receiver_max_balance.hasValue(),
-                    receiver_max_balance.value() < App.localGet(Int(1), Bytes("balance")) + transfer_amount
-                )
-            ),
-            Return(Int(0))
-        ),
         App.localPut(Int(0), Bytes("balance"), App.localGet(Int(0), Bytes("balance")) - transfer_amount),
         App.localPut(Int(1), Bytes("balance"), App.localGet(Int(1), Bytes("balance")) + transfer_amount),
         Return(Int(1))

--- a/security_token_approval.teal
+++ b/security_token_approval.teal
@@ -400,24 +400,15 @@ txn NumAccounts
 int 1
 ==
 &&
-txna ApplicationArgs 1
-btoi
 int 0
 byte "balance"
 app_local_get
-<=
-&&
-bnz l29
-err
-l29:
-int 1
-global CurrentApplicationID
-byte "maxBalance"
-app_local_get_ex
-store 2
-store 3
+txna ApplicationArgs 1
+btoi
+<
 byte "paused"
 app_global_get
+||
 int 0
 byte "frozen"
 app_local_get
@@ -458,8 +449,12 @@ app_global_get
 global LatestTimestamp
 >=
 ||
-load 2
-load 3
+int 1
+byte "maxBalance"
+app_local_get
+int 1
+byte "maxBalance"
+app_local_get
 int 1
 byte "balance"
 app_local_get
@@ -469,10 +464,11 @@ btoi
 <
 &&
 ||
-bz l30
-int 0
-return
-l30:
+!
+&&
+bnz l29
+err
+l29:
 int 0
 byte "balance"
 int 0

--- a/security_token_approval.teal
+++ b/security_token_approval.teal
@@ -47,14 +47,18 @@ txna ApplicationArgs 0
 byte "transfer"
 ==
 bnz l11
+txna ApplicationArgs 0
+byte "detectTransferRestriction"
+==
+bnz l12
 err
 l0:
 txn NumAppArgs
 int 4
 ==
-bnz l13
+bnz l14
 err
-l13:
+l14:
 byte "totalSupply"
 txna ApplicationArgs 0
 btoi
@@ -90,11 +94,11 @@ int 15
 app_local_put
 int 1
 return
-b l12
+b l13
 l1:
 int 0
 return
-b l12
+b l13
 l2:
 int 0
 byte "roles"
@@ -102,11 +106,11 @@ app_local_get
 int 8
 &
 return
-b l12
+b l13
 l3:
 int 0
 return
-b l12
+b l13
 l4:
 int 0
 byte "balance"
@@ -118,14 +122,14 @@ int 1
 app_local_put
 int 1
 return
-b l12
+b l13
 l5:
 txn NumAppArgs
 int 2
 ==
-bnz l14
+bnz l15
 err
-l14:
+l15:
 byte "paused"
 txna ApplicationArgs 1
 btoi
@@ -136,7 +140,7 @@ app_local_get
 int 8
 &
 return
-b l12
+b l13
 l6:
 int 0
 byte "roles"
@@ -156,21 +160,21 @@ btoi
 int 15
 <=
 &&
-bnz l15
+bnz l16
 err
-l15:
+l16:
 txn Sender
 txna Accounts 1
 ==
-bz l16
+bz l17
 txna ApplicationArgs 1
 btoi
 int 8
 &
-bnz l17
+bnz l18
 err
+l18:
 l17:
-l16:
 int 1
 byte "roles"
 txna ApplicationArgs 1
@@ -178,7 +182,7 @@ btoi
 app_local_put
 int 1
 return
-b l12
+b l13
 l7:
 int 0
 byte "roles"
@@ -189,14 +193,14 @@ txn NumAppArgs
 int 4
 ==
 &&
-bnz l18
+bnz l19
 err
-l18:
+l19:
 txna ApplicationArgs 3
 btoi
 int 0
 ==
-bnz l19
+bnz l20
 byte "rule"
 txna ApplicationArgs 1
 btoi
@@ -209,8 +213,8 @@ concat
 txna ApplicationArgs 3
 btoi
 app_global_put
-b l20
-l19:
+b l21
+l20:
 byte "rule"
 txna ApplicationArgs 1
 btoi
@@ -221,10 +225,10 @@ btoi
 itob
 concat
 app_global_del
-l20:
+l21:
 int 1
 return
-b l12
+b l13
 l8:
 int 0
 byte "roles"
@@ -239,9 +243,9 @@ txn NumAccounts
 int 1
 ==
 &&
-bnz l21
+bnz l22
 err
-l21:
+l22:
 int 1
 byte "frozen"
 txna ApplicationArgs 1
@@ -251,34 +255,34 @@ txna ApplicationArgs 2
 btoi
 int 0
 ==
-bnz l22
+bnz l23
 int 1
 byte "maxBalance"
 txna ApplicationArgs 2
 btoi
 app_local_put
-b l23
-l22:
+b l24
+l23:
 int 1
 byte "maxBalance"
 app_local_del
-l23:
+l24:
 txna ApplicationArgs 3
 btoi
 int 0
 ==
-bnz l24
+bnz l25
 int 1
 byte "lockUntil"
 txna ApplicationArgs 3
 btoi
 app_local_put
-b l25
-l24:
+b l26
+l25:
 int 1
 byte "lockUntil"
 app_local_del
-l25:
+l26:
 int 1
 byte "transferGroup"
 txna ApplicationArgs 4
@@ -286,7 +290,7 @@ btoi
 app_local_put
 int 1
 return
-b l12
+b l13
 l9:
 int 0
 byte "roles"
@@ -307,9 +311,9 @@ byte "reserve"
 app_global_get
 <=
 &&
-bnz l26
+bnz l27
 err
-l26:
+l27:
 int 1
 global CurrentApplicationID
 byte "maxBalance"
@@ -326,10 +330,10 @@ btoi
 +
 <
 &&
-bz l27
+bz l28
 int 0
 return
-l27:
+l28:
 byte "reserve"
 byte "reserve"
 app_global_get
@@ -348,7 +352,7 @@ btoi
 app_local_put
 int 1
 return
-b l12
+b l13
 l10:
 int 0
 byte "roles"
@@ -370,9 +374,9 @@ byte "balance"
 app_local_get
 <=
 &&
-bnz l28
+bnz l29
 err
-l28:
+l29:
 byte "reserve"
 byte "reserve"
 app_global_get
@@ -391,7 +395,7 @@ btoi
 app_local_put
 int 1
 return
-b l12
+b l13
 l11:
 txn NumAppArgs
 int 2
@@ -466,9 +470,9 @@ btoi
 ||
 !
 &&
-bnz l29
+bnz l30
 err
-l29:
+l30:
 int 0
 byte "balance"
 int 0
@@ -489,4 +493,84 @@ btoi
 app_local_put
 int 1
 return
+b l13
 l12:
+txn NumAppArgs
+int 2
+==
+txn NumAccounts
+int 2
+==
+&&
+int 1
+byte "balance"
+app_local_get
+txna ApplicationArgs 1
+btoi
+<
+byte "paused"
+app_global_get
+||
+int 1
+byte "frozen"
+app_local_get
+||
+int 1
+byte "lockUntil"
+app_local_get
+global LatestTimestamp
+>=
+||
+byte "rule"
+int 1
+byte "transferGroup"
+app_local_get
+itob
+concat
+int 2
+byte "transferGroup"
+app_local_get
+itob
+concat
+app_global_get
+int 1
+<
+||
+byte "rule"
+int 1
+byte "transferGroup"
+app_local_get
+itob
+concat
+int 2
+byte "transferGroup"
+app_local_get
+itob
+concat
+app_global_get
+global LatestTimestamp
+>=
+||
+int 2
+byte "maxBalance"
+app_local_get
+int 2
+byte "maxBalance"
+app_local_get
+int 2
+byte "balance"
+app_local_get
+txna ApplicationArgs 1
+btoi
++
+<
+&&
+||
+!
+&&
+bnz l31
+err
+l31:
+int 1
+return
+l13:


### PR DESCRIPTION
#### 1. Adds `detectTransferRestriction` function to check whether the transfer is allowed:

```bash
 goal app call --app-id uint --from address --app-account senderAddr --app-account receiverAddr --app-arg 'str:detectTransferRestriction' --app-arg "int:amount"
```

#### 2. Extracts transfer restrictions check into separate method to use in both `transfer` and `detectTransferRestriction` functions.