### PR TITLE
Stop frozen addresses from receiving transfers

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ The TEAL assembly smart contract language uses program branches with no loops (i
 | [OptIn](bin/optin.sh) | Called by anyone who will use the app before they use the app | any account |
 | ["pause"](tests/pause_contract.test.js) | Freezes all transfers of the token for all token holders. | contract admin |
 | ["grantRoles"](tests/permissions.test.js) | Sets account contract permissions. Accepts  an integer between 0 - 15 for the corresponding 4-bit bitmask permissions. See: [Appendix 1: Roles Matrix](#roles-matrix) for details. | contract admin |
-| ["setAddressPermissions"](tests/set_transfer_restrictions.test.js) | Sets account transfer restrictions:<br />1) `freeze` the address from making transfers. It can still receive transfers in.<br />2) `maxBalance` sets the max number of tokens an account can hold. Transfers into the address cannot exceed this amount.<br />3) `lockUntil` stops transfers from the address until the specified date. A locked address can still receive tokens but it cannot send them until the lockup time.<br />4) `transfer group` –  sets the category of an address for use in transfer group rules. The default category is 1. | wallets admin |
+| ["setAddressPermissions"](tests/set_transfer_restrictions.test.js) | Sets account transfer restrictions:<br />1) `freeze` the address from sending and receiving tokens.<br />2) `maxBalance` sets the max number of tokens an account can hold. Transfers into the address cannot exceed this amount.<br />3) `lockUntil` stops transfers from the address until the specified date. A locked address can still receive tokens but it cannot send them until the lockup time.<br />4) `transfer group` –  sets the category of an address for use in transfer group rules. The default category is 1. | wallets admin |
 | ["setTransferRule"](bin/transfer-group-lock.sh) | Specifies a lockUntil time for transfers between a transfer from-group and a to-group. Transfers can between groups can only occur after the lockUntil time. The lockUntil time is specified as a Unix timestamp integer in seconds since the Unix Epoch. By default transfers beetween groups are not allowed. To allow a transfer set a timestamp in the past such as "1" - for the from and to group pair . The special transfer group default number "0" means the transfer is blocked. | transfer rules admin |
 | ["mint"](bin/mint.sh) | Create new tokens from the reserve | reserve admin |
 | ["burn"](tests/burn.test.js) | Destroy tokens from a specified address | reserve admin |
@@ -190,11 +190,13 @@ The TEAL assembly smart contract language uses program branches with no loops (i
 
 # Q&A
 
-## (QSP-1) Why can frozen and locked accounts receive transfers?
+## (QSP-1) Why locked accounts can receive transfers but frozen accounts cannot?
 
-The freezing and locking of accounts applies to transfers out of the account. This allows transfer restrictions to be applied to wallet addresses prior to transferring tokens to them so there is no gap in applying token issuer rules to wallets.
+Account locking is intended for enforcing token lockup periods. For example when Reg D US investors purchase a security they must hold the security for a period of time before transferring. The locking of accounts applies to transfers out of the account but not to transfers into the account. This allows transfer restrictions to be applied to wallet addresses prior to transferring tokens to them so there is no gap in applying token issuer rules to wallets.
 
-By default a wallet cannot be transferred to. In order to transfer into a wallet, a transfer rule must be in place allowing transfers from transfer group x to transfer group y. To keep a wallet from receiving any transfers change the transfer group to a group that does not have any group that is allowed to transfer groups to it. It is recommended that the default transfer group 0 does not have a rule that allows transfers to it.
+In contrast, the intended use for freezing accounts is to stop wallet addresses in bad standing from transferring or receiving tokens. For example, after a theft or key loss. Frozen accounts are blocked from receiving tokens so that peers do not accidentally transfer to these addresses where tokens may be unrecoverable without administrator role intervention. Administrator role intervention should be an exceptional case.
+
+By default a wallet group cannot be transferred to. In order to transfer into a wallet, a transfer rule must be in place allowing transfers from transfer group x to transfer group y. To keep a wallet from receiving any transfers change the transfer group to a group that does not have any group that is allowed to transfer groups to it. It is recommended that the default transfer group 1 does not have a rule that allows transfers to it.
 
 ## (QSP-5) Users can have their tokens burnt, what keeps this from happening by accident or unilaterally?
 

--- a/security_token.py
+++ b/security_token.py
@@ -91,10 +91,9 @@ def approval_program():
     grant_roles = Seq([
         Assert(And(
             is_contract_admin,
-            Txn.accounts.length() == Int(1),
             roles <= Int(15)
         )),
-        If( 
+        If(
             Eq(Txn.sender(), Txn.accounts[1]),
             Assert(BitwiseAnd(roles, Int(8)))
         ),
@@ -193,6 +192,7 @@ def approval_program():
             Lt(App.localGet(sender_idx, Bytes("balance")), amount), # check sender balance
             App.globalGet(Bytes("paused")), # can't transfer when the contract is paused
             App.localGet(sender_idx, Bytes("frozen")), # sender account can't be frozen
+            App.localGet(receiver_idx, Bytes("frozen")), # receiver account can't be frozen
             App.localGet(sender_idx, Bytes("lockUntil")) >= Global.latest_timestamp(), # sender account can't be locked
 
             # check that a transfer rule exists and allows the transfer from the sender to the receiver at the current time

--- a/security_token_approval.teal
+++ b/security_token_approval.teal
@@ -146,10 +146,6 @@ byte "roles"
 app_local_get
 int 8
 &
-txn NumAccounts
-int 1
-==
-&&
 txna ApplicationArgs 1
 btoi
 int 15
@@ -365,6 +361,10 @@ int 0
 byte "frozen"
 app_local_get
 ||
+int 1
+byte "frozen"
+app_local_get
+||
 int 0
 byte "lockUntil"
 app_local_get
@@ -455,6 +455,10 @@ byte "paused"
 app_global_get
 ||
 int 1
+byte "frozen"
+app_local_get
+||
+int 2
 byte "frozen"
 app_local_get
 ||

--- a/tests/freeze_address.test.js
+++ b/tests/freeze_address.test.js
@@ -90,12 +90,16 @@ test('freezing an address stops transfers to the address', async () => {
 })
 
 test('an unfrozen address can transfer', async () => {
+    // confirm initial sender balance
+    localState = await util.readLocalState(clientV2, adminAccount, appId)
+    expect(localState["balance"]["ui"]).toEqual(27)
+
+    // transfer to the account to be frozen
+    appArgs = [EncodeBytes("transfer"), EncodeUint('11')]
+    await util.appCall(clientV2, adminAccount, appId, appArgs, [receiverAccount.addr])
+
     // freeze account
     appArgs = [EncodeBytes("setAddressPermissions"), EncodeUint('1'), EncodeUint('0'), EncodeUint('0'), EncodeUint('1')]
-    await util.appCall(clientV2, adminAccount, appId, appArgs, [receiverAccount.addr])
-    
-    // can still transfer to the account
-    appArgs = [EncodeBytes("transfer"), EncodeUint('11')]
     await util.appCall(clientV2, adminAccount, appId, appArgs, [receiverAccount.addr])
 
     // unfreeze account
@@ -106,12 +110,12 @@ test('an unfrozen address can transfer', async () => {
     appArgs = [EncodeBytes("transfer"), EncodeUint('11')]
     await util.appCall(clientV2, receiverAccount, appId, appArgs, [adminAccount.addr])
 
-    // check frozen sender has same amount of tokens
+    // check unfrozen sender sent back the tokens and they have a o balance
     localState = await util.readLocalState(clientV2, receiverAccount, appId)
     expect(localState["frozen"]["ui"]).toEqual(undefined)
     expect(localState["balance"]["ui"]).toEqual(undefined)
 
-    // and they didn't get transferred back
+    // and the original sender has the correct number of tokens after receiving tokens baack
     localState = await util.readLocalState(clientV2, adminAccount, appId)
     expect(localState["balance"]["ui"]).toEqual(27)
 })

--- a/tests/grant_roles.test.js
+++ b/tests/grant_roles.test.js
@@ -42,6 +42,29 @@ test('contract admin role can be granted by contract admin', async () => {
   expect(localState["roles"]["ui"]).toEqual(15)
 })
 
+test('passing in two app-accounts only sets the role for the first account', async () => {
+  // the guard clause checking the number of accounts was removed
+  // but there is not side effect to calling grant role with a second address
+
+  let extraAccount = accounts[2]
+  expect(extraAccount.addr.length).toBe(58)
+  await util.optInApp(clientV2, extraAccount, appId)
+
+  let transferGroupLock1 =
+      `goal app call --app-id ${appId} --from ${adminAccount.addr} ` +
+      `--app-account ${receiverAccount.addr} --app-account ${extraAccount.addr} ` +
+      `--app-arg 'str:grantRoles' --app-arg "int:8" ` +
+      `-d devnet/Primary`
+
+  await shell.exec(transferGroupLock1, {async: false, silent: true})
+
+  localState = await util.readLocalState(clientV2, receiverAccount, appId)
+  expect(localState["roles"]["ui"]).toEqual(8)
+
+  localState = await util.readLocalState(clientV2, extraAccount, appId)
+  expect(localState["roles"]).toEqual(undefined)
+})
+
 test('contract admin role can be revoked by contract admin', async () => {
   appArgs = [
     EncodeBytes("grantRoles"),


### PR DESCRIPTION
This is a minor fix to address a concern that peer to peer transfers could be made to a frozen account. This changes the behavior so that frozen accounts cannot receive transfers. Even prior to this change frozen accounts cannot make transfers.

This would be a 1 line fix, but Algorand has a 1000 byte limit and the contract was already pushing the limit. In order to accommodate the one line change I needed to remove something to lower the byte limit. After trying a few approaches I removed a `Txn.accounts.length() == Int(1)` check. It checks that the expected number of arguments was passed in and it arguably is a redundant check. The change should not cause side effects after removal.